### PR TITLE
add integrity hashes to icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,24 +9,28 @@
       rel="icon"
       type="image/vnd.microsoft.icon"
       sizes="any"
+      integrity="sha384-dF/znGP2m9ejHa0pkO3gBlYZ2obKWR0wJ91Sxoap4JI/VGDjkLVNiLKaWBN8m0NL"
     />
     <link
       href="https://cdn.figure.com/shared-assets/favicons/figure/favicon-16x16.png"
       rel="icon"
       type="image/png"
       sizes="16x16"
+      integrity="sha384-PIrX8Ez9AtZkYfDtToKOPy/8E71T+Ca+HPApoPNhhOYPie7b4otOX0VUJkk1XXI1"
     />
     <link
       href="https://cdn.figure.com/shared-assets/favicons/figure/favicon-32x32.png"
       rel="icon"
       type="image/png"
       sizes="32x32"
+      integrity="sha384-RW1RnjaxDERkb/pvQzuF6cXP3v9yE8VOksM7LpHh/9PyjPt7zHS5CJKMaj8ZGmrQ"
     />
     <link
       href="https://cdn.figure.com/shared-assets/favicons/figure/apple-touch-icon-180x180.png"
       rel="apple-touch-icon"
       type="image/png"
       sizes="180x180"
+      integrity="sha384-6BRd/pis7oF7RqRtKIl44fn5FzCrQpc9mc7eML2e13rgpSsQ+vMZW0vjStRVYsYC"
     />
     <link href="https://cdn.figure.com" rel="preconnect" />
   </head>


### PR DESCRIPTION
We need to add integrity hashes to the icons to quiet Semgrep warnings.